### PR TITLE
Add React frontend structure

### DIFF
--- a/repos/Ansible_Automation_UI/frontend/index.html
+++ b/repos/Ansible_Automation_UI/frontend/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ansible Automation UI</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="bg-gray-100">
+    <div id="root"></div>
+    <!-- Load our React app -->
+    <script type="text/babel" data-type="module" src="./src/index.js"></script>
+</body>
+</html>

--- a/repos/Ansible_Automation_UI/frontend/src/App.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/App.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from "https://cdn.skypack.dev/react";
+import Navbar from "./components/Navbar.jsx";
+import Sidebar from "./components/Sidebar.jsx";
+import AdminPage from "./pages/AdminPage.jsx";
+import OperatorPage from "./pages/OperatorPage.jsx";
+import LoginPage from "./pages/LoginPage.jsx";
+import authService from "./services/authService.js";
+
+export default function App() {
+  const [user, setUser] = useState(null); // {username, role}
+
+  const handleLogin = async (username, password) => {
+    const result = await authService.login(username, password);
+    if (result) {
+      setUser({ username, role: result.role });
+    } else {
+      alert("Login failed");
+    }
+  };
+
+  const handleLogout = async () => {
+    await authService.logout();
+    setUser(null);
+  };
+
+  return (
+    <div className="flex h-screen">
+      {user && <Sidebar role={user.role} onLogout={handleLogout} />}
+      <div className="flex-1 flex flex-col">
+        <Navbar user={user} />
+        <div className="p-4 flex-1 overflow-auto">
+          {!user && <LoginPage onLogin={handleLogin} />}
+          {user?.role === "admin" && <AdminPage />}
+          {user?.role === "operator" && <OperatorPage />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/components/Navbar.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/components/Navbar.jsx
@@ -1,0 +1,10 @@
+import React from "https://cdn.skypack.dev/react";
+
+export default function Navbar({ user }) {
+  return (
+    <nav className="bg-blue-600 text-white px-4 py-2 flex justify-between">
+      <span className="font-bold">Ansible Automation UI</span>
+      <span>{user ? `Logged in as ${user.username}` : ""}</span>
+    </nav>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/components/Notification.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/components/Notification.jsx
@@ -1,0 +1,9 @@
+import React from "https://cdn.skypack.dev/react";
+
+export default function Notification({ message }) {
+  return (
+    <div className="mt-2 p-2 bg-green-200 text-green-800 rounded">
+      {message}
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/components/PlaybookCard.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/components/PlaybookCard.jsx
@@ -1,0 +1,17 @@
+import React from "https://cdn.skypack.dev/react";
+
+export default function PlaybookCard({ name, onRun }) {
+  return (
+    <div className="border p-2 rounded shadow flex justify-between items-center">
+      <span>{name}</span>
+      {onRun && (
+        <button
+          className="bg-green-500 text-white px-2 py-1 rounded"
+          onClick={() => onRun(name)}
+        >
+          Run
+        </button>
+      )}
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/components/PlaybookForm.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/components/PlaybookForm.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from "https://cdn.skypack.dev/react";
+import playbookService from "../services/playbookService.js";
+import Notification from "./Notification.jsx";
+
+export default function PlaybookForm() {
+  const [name, setName] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [message, setMessage] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const res = await playbookService.generatePlaybook(name, prompt);
+    setMessage(res ? `Created ${name}` : "Error generating");
+    setName("");
+    setPrompt("");
+  };
+
+  return (
+    <div className="mb-4">
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          className="border p-1 w-full"
+          placeholder="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <textarea
+          className="border p-1 w-full"
+          placeholder="Prompt"
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          required
+        />
+        <button className="bg-blue-500 text-white px-2 py-1 rounded" type="submit">
+          Generate
+        </button>
+      </form>
+      {message && <Notification message={message} />}
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/components/PlaybookList.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/components/PlaybookList.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from "https://cdn.skypack.dev/react";
+import PlaybookCard from "./PlaybookCard.jsx";
+import playbookService from "../services/playbookService.js";
+
+export default function PlaybookList({ showRun }) {
+  const [playbooks, setPlaybooks] = useState([]);
+
+  const load = async () => {
+    const list = await playbookService.listPlaybooks();
+    setPlaybooks(list || []);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const run = async (name) => {
+    await playbookService.runPlaybook(name);
+    alert(`Executed ${name}`);
+  };
+
+  return (
+    <div className="space-y-2">
+      {playbooks.map((pb) => (
+        <PlaybookCard key={pb} name={pb} onRun={showRun ? run : null} />
+      ))}
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/components/Sidebar.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,15 @@
+import React from "https://cdn.skypack.dev/react";
+
+export default function Sidebar({ role, onLogout }) {
+  return (
+    <aside className="w-48 bg-gray-800 text-white p-4 space-y-2">
+      <div className="font-bold mb-2 capitalize">{role} Panel</div>
+      <button
+        className="bg-red-500 w-full py-1 rounded"
+        onClick={onLogout}
+      >
+        Logout
+      </button>
+    </aside>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/components/TestConnection.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/components/TestConnection.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from "https://cdn.skypack.dev/react";
+import deviceService from "../services/deviceService.js";
+import Notification from "./Notification.jsx";
+
+export default function TestConnection() {
+  const [device, setDevice] = useState("");
+  const [message, setMessage] = useState(null);
+
+  const handleTest = async (e) => {
+    e.preventDefault();
+    const res = await deviceService.onboard(device);
+    setMessage(res ? `Connected to ${device}` : "Connection failed");
+    setDevice("");
+  };
+
+  return (
+    <div className="mb-4">
+      <form onSubmit={handleTest} className="space-y-2">
+        <input
+          className="border p-1 w-full"
+          placeholder="Device"
+          value={device}
+          onChange={(e) => setDevice(e.target.value)}
+          required
+        />
+        <button className="bg-blue-500 text-white px-2 py-1 rounded" type="submit">
+          Test Connection
+        </button>
+      </form>
+      {message && <Notification message={message} />}
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/index.js
+++ b/repos/Ansible_Automation_UI/frontend/src/index.js
@@ -1,0 +1,5 @@
+import React from "https://cdn.skypack.dev/react";
+import ReactDOM from "https://cdn.skypack.dev/react-dom";
+import App from "./App.jsx";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/repos/Ansible_Automation_UI/frontend/src/pages/AdminPage.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/pages/AdminPage.jsx
@@ -1,0 +1,14 @@
+import React from "https://cdn.skypack.dev/react";
+import PlaybookForm from "../components/PlaybookForm.jsx";
+import PlaybookList from "../components/PlaybookList.jsx";
+
+export default function AdminPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Generate Playbook</h2>
+      <PlaybookForm />
+      <h2 className="text-xl font-bold">Available Playbooks</h2>
+      <PlaybookList />
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/pages/LoginPage.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from "https://cdn.skypack.dev/react";
+
+export default function LoginPage({ onLogin }) {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handle = (e) => {
+    e.preventDefault();
+    onLogin(username, password);
+  };
+
+  return (
+    <form onSubmit={handle} className="max-w-sm mx-auto mt-20 space-y-2">
+      <input
+        className="border p-1 w-full"
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+        required
+      />
+      <input
+        type="password"
+        className="border p-1 w-full"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        required
+      />
+      <button className="bg-blue-500 text-white px-2 py-1 rounded w-full" type="submit">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/pages/OperatorPage.jsx
+++ b/repos/Ansible_Automation_UI/frontend/src/pages/OperatorPage.jsx
@@ -1,0 +1,14 @@
+import React from "https://cdn.skypack.dev/react";
+import TestConnection from "../components/TestConnection.jsx";
+import PlaybookList from "../components/PlaybookList.jsx";
+
+export default function OperatorPage() {
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold">Onboard Device</h2>
+      <TestConnection />
+      <h2 className="text-xl font-bold">Run Playbook</h2>
+      <PlaybookList showRun={true} />
+    </div>
+  );
+}

--- a/repos/Ansible_Automation_UI/frontend/src/services/authService.js
+++ b/repos/Ansible_Automation_UI/frontend/src/services/authService.js
@@ -1,0 +1,19 @@
+const API = ""; // same origin
+
+async function login(username, password) {
+  const res = await fetch(`${API}/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  if (res.ok) {
+    return { role: username === "admin" ? "admin" : "operator" };
+  }
+  return null;
+}
+
+async function logout() {
+  await fetch(`${API}/logout`, { method: "POST" });
+}
+
+export default { login, logout };

--- a/repos/Ansible_Automation_UI/frontend/src/services/deviceService.js
+++ b/repos/Ansible_Automation_UI/frontend/src/services/deviceService.js
@@ -1,0 +1,12 @@
+const API = "";
+
+async function onboard(device) {
+  const res = await fetch(`${API}/onboard`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ device }),
+  });
+  return res.ok;
+}
+
+export default { onboard };

--- a/repos/Ansible_Automation_UI/frontend/src/services/playbookService.js
+++ b/repos/Ansible_Automation_UI/frontend/src/services/playbookService.js
@@ -1,0 +1,28 @@
+const API = "";
+
+async function generatePlaybook(name, prompt) {
+  const res = await fetch(`${API}/generate_playbook`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, prompt }),
+  });
+  return res.ok;
+}
+
+async function listPlaybooks() {
+  const res = await fetch(`${API}/playbooks`);
+  if (res.ok) {
+    return res.json();
+  }
+  return [];
+}
+
+async function runPlaybook(name) {
+  await fetch(`${API}/run_playbook`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+}
+
+export default { generatePlaybook, listPlaybooks, runPlaybook };

--- a/repos/Ansible_Automation_UI/frontend/tailwind.config.js
+++ b/repos/Ansible_Automation_UI/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{js,jsx,html}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add simple React frontend with components, pages, and services
- provide Tailwind config and HTML entrypoint

## Testing
- `python3 -m py_compile repos/Ansible_Automation_UI/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685173a6b52883268caa1bc4f692781b